### PR TITLE
Remove Vec<u8> from ObjectHash trait

### DIFF
--- a/src/hasher/ring.rs
+++ b/src/hasher/ring.rs
@@ -19,13 +19,14 @@ impl Hasher {
 }
 
 impl ObjectHasher for Hasher {
+    type D = digest::Digest;
+
     fn write(&mut self, bytes: &[u8]) {
         self.ctx.update(bytes);
     }
 
-    fn finish(self) -> Vec<u8> {
-        let digest = self.ctx.finish();
-        Vec::from(digest.as_ref())
+    fn finish(self) -> digest::Digest {
+        self.ctx.finish()
     }
 }
 
@@ -44,6 +45,6 @@ mod tests {
     fn sha256_test_vector() {
         let mut hasher = Hasher::new();
         hasher.write(SHA256_VECTOR_STRING.as_bytes());
-        assert_eq!(hasher.finish().to_hex(), SHA256_VECTOR_DIGEST);
+        assert_eq!(hasher.finish().as_ref().to_hex(), SHA256_VECTOR_DIGEST);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,12 +8,14 @@ mod types;
 pub fn digest<T: ObjectHash>(msg: &T) -> Vec<u8> {
     let mut hasher = hasher::default();
     msg.objecthash(&mut hasher);
-    hasher.finish()
+    let digest = hasher.finish();
+    Vec::from(digest.as_ref())
 }
 
 pub trait ObjectHasher {
+    type D: AsRef<[u8]>;
     fn write(&mut self, bytes: &[u8]);
-    fn finish(self) -> Vec<u8>;
+    fn finish(self) -> Self::D;
 }
 
 pub trait ObjectHash {

--- a/src/types.rs
+++ b/src/types.rs
@@ -30,13 +30,13 @@ mod tests {
     fn test_i32(val: i32, expected_digest_hex: &str) {
         let mut hasher = hasher::default();
         val.objecthash(&mut hasher);
-        assert_eq!(hasher.finish().to_hex(), expected_digest_hex);
+        assert_eq!(hasher.finish().as_ref().to_hex(), expected_digest_hex);
     }
 
     fn test_u32(val: u32, expected_digest_hex: &str) {
         let mut hasher = hasher::default();
         val.objecthash(&mut hasher);
-        assert_eq!(hasher.finish().to_hex(), expected_digest_hex);
+        assert_eq!(hasher.finish().as_ref().to_hex(), expected_digest_hex);
     }
 
     #[test]


### PR DESCRIPTION
Instead have finish() return a digest object we can call as_ref() on
