### PR TITLE
[u8] support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ version = ">= 0.3.19"
 [features]
 default = ["objecthash-ring"]
 objecthash-ring = ["ring"]
+octet-strings = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,14 +3,6 @@ extern crate unicode_normalization;
 #[cfg(test)]
 extern crate rustc_serialize;
 
-#[macro_export]
-macro_rules! objecthash_digest {
-    ($hasher:expr, $tag:expr, $bytes:expr) => {
-        $hasher.write($tag);
-        $hasher.write($bytes);
-    };
-}
-
 pub mod hasher;
 mod types;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,6 +7,16 @@ const INTEGER_TAG: &'static [u8; 1] = b"i";
 const STRING_TAG: &'static [u8; 1] = b"u";
 const LIST_TAG: &'static [u8; 1] = b"l";
 
+#[cfg(feature = "octet-strings")]
+const OCTET_TAG: &'static [u8; 1] = b"o";
+
+macro_rules! objecthash_digest {
+    ($hasher:expr, $tag:expr, $bytes:expr) => {
+        $hasher.write($tag);
+        $hasher.write($bytes);
+    };
+}
+
 impl<T: ObjectHash> ObjectHash for Vec<T> {
     #[inline]
     fn objecthash<H: ObjectHasher>(&self, hasher: &mut H) {
@@ -25,6 +35,16 @@ impl ObjectHash for str {
     fn objecthash<H: ObjectHasher>(&self, hasher: &mut H) {
         let normalized = self.nfc().collect::<String>();
         objecthash_digest!(hasher, STRING_TAG, normalized.as_bytes());
+    }
+}
+
+// Technically ObjectHash does not define a representation for binary data
+// For now this is a non-standard extension of ObjectHash
+#[cfg(feature = "octet-strings")]
+impl ObjectHash for [u8] {
+    #[inline]
+    fn objecthash<H: ObjectHasher>(&self, hasher: &mut H) {
+        objecthash_digest!(hasher, OCTET_TAG, self);
     }
 }
 


### PR DESCRIPTION
This adds an optional, nonstandard extension to ObjectHash for computing hashes of binary data.

By default, ObjectHash only supports Unicode strings.

I would like to get these changes more widely supported in other ObjectHash implementations, but for now they're flagged as optional because they're nonstandard.

cc @benlaurie
