### PR TITLE
Hasher::write -> update, update_nested

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,8 @@ pub fn digest<T: ObjectHash>(msg: &T) -> Vec<u8> {
 
 pub trait ObjectHasher {
     type D: AsRef<[u8]>;
-    fn write(&mut self, bytes: &[u8]);
+    fn update(&mut self, bytes: &[u8]);
+    fn update_nested<F>(&mut self, nested: F) where F: Fn(&mut Self);
     fn finish(self) -> Self::D;
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,5 @@
 use {ObjectHash, ObjectHasher};
 
-use hasher;
 use unicode_normalization::UnicodeNormalization;
 
 const INTEGER_TAG: &'static [u8; 1] = b"i";
@@ -12,20 +11,18 @@ const OCTET_TAG: &'static [u8; 1] = b"o";
 
 macro_rules! objecthash_digest {
     ($hasher:expr, $tag:expr, $bytes:expr) => {
-        $hasher.write($tag);
-        $hasher.write($bytes);
+        $hasher.update($tag);
+        $hasher.update($bytes);
     };
 }
 
 impl<T: ObjectHash> ObjectHash for Vec<T> {
     #[inline]
     fn objecthash<H: ObjectHasher>(&self, hasher: &mut H) {
-        hasher.write(LIST_TAG);
+        hasher.update(LIST_TAG);
 
         for value in self {
-            let mut value_hasher = hasher::default();
-            value.objecthash(&mut value_hasher);
-            hasher.write(value_hasher.finish().as_ref());
+            hasher.update_nested(|h| value.objecthash(h));
         }
     }
 }


### PR DESCRIPTION
Support for hashing nested object graphs, abstracting the creation of new digest contexts into ObjectHasher.
