### PR TITLE
Digest type

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ implements the ObjectHash trait.
 
 ## TODO
 
-* Zero allocation API
 * More types
 * More test vectors
 * Redaction support

--- a/src/hasher/ring.rs
+++ b/src/hasher/ring.rs
@@ -22,6 +22,11 @@ impl ObjectHasher for Hasher {
     type D = digest::Digest;
 
     #[inline]
+    fn output_len(&self) -> usize {
+        self.ctx.algorithm.output_len
+    }
+
+    #[inline]
     fn update(&mut self, bytes: &[u8]) {
         self.ctx.update(bytes);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,16 +6,38 @@ extern crate rustc_serialize;
 pub mod hasher;
 mod types;
 
+const MAX_OUTPUT_LEN: usize = 32;
+
+pub struct Digest {
+    output_len: usize,
+    value: [u8; MAX_OUTPUT_LEN],
+}
+
+impl AsRef<[u8]> for Digest {
+    #[inline(always)]
+    fn as_ref(&self) -> &[u8] {
+        &self.value[..self.output_len]
+    }
+}
+
 #[cfg(feature = "objecthash-ring")]
-pub fn digest<T: ObjectHash>(msg: &T) -> Vec<u8> {
+pub fn digest<T: ObjectHash>(msg: &T) -> Digest {
     let mut hasher = hasher::default();
     msg.objecthash(&mut hasher);
-    let digest = hasher.finish();
-    Vec::from(digest.as_ref())
+
+    let output_len = hasher.output_len();
+    let mut digest_bytes = [0u8; MAX_OUTPUT_LEN];
+    digest_bytes.copy_from_slice(hasher.finish().as_ref());
+
+    Digest {
+        output_len: output_len,
+        value: digest_bytes
+    }
 }
 
 pub trait ObjectHasher {
     type D: AsRef<[u8]>;
+    fn output_len(&self) -> usize;
     fn update(&mut self, bytes: &[u8]);
     fn update_nested<F>(&mut self, nested: F) where F: Fn(&mut Self);
     fn finish(self) -> Self::D;
@@ -34,7 +56,7 @@ mod tests {
     #[test]
     fn digest_test() {
         let result = digest(&1000);
-        assert_eq!(result.to_hex(),
+        assert_eq!(result.as_ref().to_hex(),
                    "a3346d18105ef801c3598fec426dcc5d4be9d0374da5343f6c8dcbdf24cb8e0b");
     }
 }


### PR DESCRIPTION
This allows us to avoid heap allocations (i.e. Vec)
